### PR TITLE
Remove unused variable in `WorldLoader` class

### DIFF
--- a/src/WorldLoader.cpp
+++ b/src/WorldLoader.cpp
@@ -492,7 +492,6 @@ WorldLoader::loadObject(AssetManager *assetManager, tinyxml2::XMLElement *object
         if(childrenCountNode == nullptr || childrenCountNode->GetText() == nullptr) {
             std::cerr << "Object has children node, but count it unknown. Children can't be loaded! " << std::endl;
                     } else {
-            uint32_t childCount = std::stoi(childrenCountNode->GetText());
             //loadedObjectInformation->model->children.resize(childCount);
             tinyxml2::XMLElement *childNode = childrenNode->FirstChildElement("Child");
             while (childNode != nullptr) {


### PR DESCRIPTION
This commit removes the unused variable `childCount` from
`src/WorldLoader.cpp`, removing compiler warnings associated with that
line.

See #77