### PR TITLE
Fix incorrect file path in `src/AssetManager.h`

### DIFF
--- a/src/Assets/AssetManager.h
+++ b/src/Assets/AssetManager.h
@@ -84,7 +84,7 @@ public:
         }
     };
 private:
-    const std::string ASSET_EXTENSIONS_FILE = "./engine/assetExtensions.xml";
+    const std::string ASSET_EXTENSIONS_FILE = "./Engine/assetExtensions.xml";
 
     //second of the pair is how many times load requested. prework for unload
     std::map<const std::vector<std::string>, std::pair<Asset *, uint32_t>> assets;


### PR DESCRIPTION
This commit fixes a (presumed) type in the hardcoded file path for the
asset extension file.

See #79 