### PR TITLE
Removing object with its children

### DIFF
--- a/src/API/LimonAPI.cpp
+++ b/src/API/LimonAPI.cpp
@@ -48,8 +48,8 @@ std::vector<LimonAPI::ParameterRequest> LimonAPI::getResultOfTrigger(uint32_t Tr
     return results;
 }
 
-bool LimonAPI::removeObject(uint32_t objectID) {
-    return worldRemoveObject(objectID);
+bool LimonAPI::removeObject(uint32_t objectID, const bool &removeChildren) {
+    return worldRemoveObject(objectID, removeChildren);
 }
 
 bool LimonAPI::removeTriggerObject(uint32_t TriggerObjectID) {

--- a/src/API/LimonAPI.h
+++ b/src/API/LimonAPI.h
@@ -137,7 +137,7 @@ public:
     uint32_t addObject(const std::string &modelFilePath, float modelWeight, bool physical, const glm::vec3 &position,
                        const glm::vec3 &scale, const glm::quat &orientation);
     bool setObjectTemporary(uint32_t modelID, bool temporary);
-    bool removeObject(uint32_t objectID);
+    bool removeObject(uint32_t objectID, const bool &removeChildren = true);
     bool attachObjectToObject(uint32_t objectID, uint32_t objectToAttachToID);//second one is
     bool removeTriggerObject(uint32_t TriggerObjectID);
     bool disconnectObjectFromPhysics(uint32_t modelID);
@@ -266,7 +266,7 @@ private:
     std::function<bool(uint32_t, const std::string &)> worldUpdateGuiText;
     std::function<uint32_t (uint32_t)> worldRemoveGuiElement;
     std::function<std::vector<LimonAPI::ParameterRequest>(uint32_t , uint32_t )> worldGetResultOfTrigger;
-    std::function<bool (uint32_t)> worldRemoveObject;
+    std::function<bool (uint32_t, bool)> worldRemoveObject;
     std::function<std::vector<LimonAPI::ParameterRequest>(uint32_t)> worldGetObjectTransformation;
     std::function<bool (uint32_t, const LimonAPI::Vec4&)> worldSetObjectTranslate;
     std::function<bool (uint32_t, const LimonAPI::Vec4&)> worldSetObjectScale;

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2351,7 +2351,15 @@ bool World::removeObject(uint32_t objectID) {
             modelsInLightFrustum[i][modelToRemove->getAssetID()].erase(modelToRemove);
         }
     }
-
+    
+	//remove its children
+	std::vector<PhysicalRenderable*> children=objects[objectID]->getChildren();
+	for (auto child = children.begin(); child != children.end(); ++child) {
+		   Model* model = dynamic_cast<Model*>(*child);
+			if(model!= nullptr) {//FIXME this eliminates non model childs
+               removeObject(model->getWorldObjectID());
+            }
+    }
 
     //delete object itself
     delete modelToRemove;

--- a/src/World.cpp
+++ b/src/World.cpp
@@ -2311,7 +2311,7 @@ bool World::removeTriggerObject(uint32_t triggerobjectID) {
     return false;//not successful
 }
 
-bool World::removeObject(uint32_t objectID) {
+bool World::removeObject(uint32_t objectID, const bool &removeChildren) {
     Model* modelToRemove = findModelByID(objectID);
     if(modelToRemove == nullptr) {
         return false;
@@ -2353,14 +2353,17 @@ bool World::removeObject(uint32_t objectID) {
     }
     
 	//remove its children
-	std::vector<PhysicalRenderable*> children=objects[objectID]->getChildren();
-	for (auto child = children.begin(); child != children.end(); ++child) {
-		   Model* model = dynamic_cast<Model*>(*child);
-			if(model!= nullptr) {//FIXME this eliminates non model childs
-               removeObject(model->getWorldObjectID());
-            }
+    if(removeChildren)
+    {
+        std::vector<PhysicalRenderable*> children=objects[objectID]->getChildren();
+        for (auto child = children.begin(); child != children.end(); ++child) {
+            Model* model = dynamic_cast<Model*>(*child);
+                if(model!= nullptr) {//FIXME this eliminates non model childs
+                removeObject(model->getWorldObjectID());
+                }
+        }
     }
-
+    
     //delete object itself
     delete modelToRemove;
     objects.erase(objectID);

--- a/src/World.h
+++ b/src/World.h
@@ -395,7 +395,7 @@ public:
 
     bool updateGuiText(uint32_t guiTextID, const std::string &newText);
 
-    bool removeObject(uint32_t objectID);
+    bool removeObject(uint32_t objectID, const bool &removeChildren = true);
     bool removeTriggerObject(uint32_t triggerobjectID);
     bool removeGuiElement(uint32_t guiElementID);
 

--- a/src/WorldLoader.cpp
+++ b/src/WorldLoader.cpp
@@ -65,7 +65,7 @@ void WorldLoader::attachedAPIMethodsToWorld(World *world, LimonAPI *limonAPI) co
     limonAPI->worldGenerateEditorElementsForParameters = std::bind(&World::generateEditorElementsForParameters, world, std::placeholders::_1, std::placeholders::_2);
     limonAPI->worldGetResultOfTrigger = std::bind(&World::getResultOfTrigger, world, std::placeholders::_1, std::placeholders::_2);
     limonAPI->worldRemoveGuiElement = std::bind(&World::removeGuiElement, world, std::placeholders::_1);
-    limonAPI->worldRemoveObject = std::bind(&World::removeObject, world, std::placeholders::_1);
+    limonAPI->worldRemoveObject = std::bind(&World::removeObject, world, std::placeholders::_1,  std::placeholders::_2);
     limonAPI->worldAttachObjectToObject = std::bind(&World::attachObjectToObject, world, std::placeholders::_1, std::placeholders::_2);
     limonAPI->worldRemoveTriggerObject = std::bind(&World::removeTriggerObject, world, std::placeholders::_1);
     limonAPI->worldDisconnectObjectFromPhysics = std::bind(&World::disconnectObjectFromPhysics, world, std::placeholders::_1);


### PR DESCRIPTION
Added removing object with its children to World::removeObject(),so attached objects like decals,will be removed after removing the parent.


fixes #101 