### PR TITLE
__attribute__((unused)) tags replacement

### DIFF
--- a/src/API/ActorInterface.h
+++ b/src/API/ActorInterface.h
@@ -83,7 +83,7 @@ public:
     virtual bool interaction(std::vector<LimonAPI::ParameterRequest> &interactionInformation) = 0;
 
     virtual std::vector<LimonAPI::ParameterRequest> getParameters() const { return std::vector<LimonAPI::ParameterRequest>();};
-    virtual void setParameters(std::vector<LimonAPI::ParameterRequest> parameters __attribute__((unused))) {};
+    virtual void setParameters(std::vector<LimonAPI::ParameterRequest> parameters [[gnu::unused]]) {};
 
     virtual ~ActorInterface() {};
 
@@ -135,9 +135,9 @@ ActorInterface* createActorT(uint32_t id, LimonAPI* limonAPI) {
 template<typename T>
 class ActorRegister : ActorInterface {
 
-    void play(long time __attribute((unused)), ActorInterface::ActorInformation &information __attribute((unused))) override {};
+    void play(long time [[gnu::unused]], ActorInterface::ActorInformation &information [[gnu::unused]]) override {};
 
-    bool interaction(std::vector<LimonAPI::ParameterRequest> &interactionInformation __attribute((unused))) override {return false;};
+    bool interaction(std::vector<LimonAPI::ParameterRequest> &interactionInformation [[gnu::unused]]) override {return false;};
 
     std::string getName() const override {
         return "This object is not meant to be used";

--- a/src/API/PlayerExtensionInterface.h
+++ b/src/API/PlayerExtensionInterface.h
@@ -87,7 +87,7 @@ class PlayerExtensionRegister : PlayerExtensionInterface {
 
     void processInput(const InputStates &inputHandler, const PlayerExtensionInterface::PlayerInformation &playerInformation,
                           long time) override {}
-    void interact(std::vector<LimonAPI::ParameterRequest> &interactionData __attribute__((unused))) override {}
+    void interact(std::vector<LimonAPI::ParameterRequest> &interactionData [[gnu::unused]]) override {}
 
 public:
     explicit PlayerExtensionRegister(std::string const& s) : PlayerExtensionInterface(nullptr) {

--- a/src/API/TriggerInterface.h
+++ b/src/API/TriggerInterface.h
@@ -73,7 +73,7 @@ class TriggerRegister : TriggerInterface {
     virtual std::vector<LimonAPI::ParameterRequest> getParameters() {
         return std::vector<LimonAPI::ParameterRequest>();
     };
-    virtual bool run(std::vector<LimonAPI::ParameterRequest> parameters __attribute((unused))) override {
+    virtual bool run(std::vector<LimonAPI::ParameterRequest> parameters [[gnu::unused]]) override {
         return false;
     };
     std::string getName() const override {

--- a/src/AnimationSequencer.cpp
+++ b/src/AnimationSequencer.cpp
@@ -47,7 +47,7 @@ void AnimationSequenceInterface::Duplicate(int index) {
     }
 }
 
-void AnimationSequenceInterface::Add(int type __attribute((unused))) {
+void AnimationSequenceInterface::Add(int type [[gnu::unused]]) {
     setTransform(selectedEntry);
     Transformation tempTr = sections[sections.size()-1].transformation;//we don't allow removing last element, so this is valid.
     sections.push_back(AnimationSequenceInterface::AnimationSequenceItem{ sections[sections.size()-1].mFrameEnd+60,  tempTr});

--- a/src/AnimationSequencer.h
+++ b/src/AnimationSequencer.h
@@ -52,7 +52,7 @@ public:
     int GetItemCount() const { return (int)sections.size(); }
 
     int GetItemTypeCount() const { return 1; }
-    const char *GetItemTypeName(int typeIndex __attribute((unused))) const { return "Section"; }
+    const char *GetItemTypeName(int typeIndex [[gnu::unused]]) const { return "Section"; }
     const char *GetItemLabel(int index) const {
         static char tmps[512];
         sprintf(tmps, "[%02d] %s", index, "Section");
@@ -78,7 +78,7 @@ public:
             *type = 0;//we don't have multiple types
         }
     }
-    void Add(int type __attribute((unused)));
+    void Add(int type [[gnu::unused]]);
     void setTransform(int32_t indexToSet);
 
 

--- a/src/Assets/Animations/AnimationCustom.cpp
+++ b/src/Assets/Animations/AnimationCustom.cpp
@@ -8,7 +8,7 @@
 #include <iostream>
 #include "AnimationNode.h"
 
-bool AnimationCustom::calculateTransform(const std::string& nodeName __attribute((unused)), float time, Transformation& transformation) const {
+bool AnimationCustom::calculateTransform(const std::string& nodeName [[gnu::unused]], float time, Transformation& transformation) const {
     transformation.setScale(animationNode->getScalingVector(time));
     transformation.setOrientation(animationNode->getRotationQuat(time));
     transformation.setTranslate(animationNode->getPositionVector(time));

--- a/src/Assets/Asset.h
+++ b/src/Assets/Asset.h
@@ -23,7 +23,7 @@ protected:
      * @param fileList Asset files to load
      * @return empty asset
      */
-    Asset(AssetManager *assetManager, uint32_t assetID, const std::vector<std::string> &fileList __attribute((unused)))
+    Asset(AssetManager *assetManager, uint32_t assetID, const std::vector<std::string> &fileList [[gnu::unused]])
             : assetManager(assetManager), assetID(assetID) {};
 
 public:

--- a/src/Assets/AssetManager.cpp
+++ b/src/Assets/AssetManager.cpp
@@ -183,7 +183,7 @@ AssetManager::getAvailableAssetsTreeFilteredRecursive(const AvailableAssetsNode 
     return newAssetsNode;
 }
 
-void AssetManager::loadUsingCereal(const std::vector<std::string> files __attribute__((unused))) {
+void AssetManager::loadUsingCereal(const std::vector<std::string> files [[gnu::unused]]) {
 #ifdef CEREAL_SUPPORT
     std::ifstream is(files[0], std::ios::binary);
     cereal::BinaryInputArchive archive(is);

--- a/src/GLHelper.h
+++ b/src/GLHelper.h
@@ -267,7 +267,7 @@ public:
     }
 
 private:
-    inline bool checkErrors(const std::string &callerFunc __attribute((unused))) {
+    inline bool checkErrors(const std::string &callerFunc [[gnu::unused]]) {
 #ifndef NDEBUG
         GLenum fbStatus = glCheckFramebufferStatus(GL_FRAMEBUFFER);
         if (fbStatus != GL_FRAMEBUFFER_COMPLETE) {

--- a/src/GUI/GUIRenderable.h
+++ b/src/GUI/GUIRenderable.h
@@ -67,7 +67,7 @@ public:
 
     virtual void renderDebug(BulletDebugDrawer *debugDrawer);
 
-    virtual void setupForTime(long time __attribute__((unused))) {};//Most of the GUI elements shouldn't care about the time, so we can put an empty implementation
+    virtual void setupForTime(long time [[gnu::unused]]) {};//Most of the GUI elements shouldn't care about the time, so we can put an empty implementation
 
     float getWidth() { return transformation.getScale().x; }
 

--- a/src/GameObjects/GameObject.h
+++ b/src/GameObjects/GameObject.h
@@ -47,9 +47,9 @@ public:
 
     virtual ObjectTypes getTypeID() const = 0;
     virtual std::string getName() const = 0;
-    virtual ImGuiResult addImGuiEditorElements(const ImGuiRequest &request __attribute((unused))) {ImGuiResult imGuiResult; return imGuiResult;};
+    virtual ImGuiResult addImGuiEditorElements(const ImGuiRequest &request [[gnu::unused]]) {ImGuiResult imGuiResult; return imGuiResult;};
 
-    virtual void interact(LimonAPI *limonAPI __attribute((unused)), std::vector<LimonAPI::ParameterRequest> &interactionData __attribute((unused))) {};
+    virtual void interact(LimonAPI *limonAPI [[gnu::unused]], std::vector<LimonAPI::ParameterRequest> &interactionData [[gnu::unused]]) {};
 
     virtual uint32_t getWorldObjectID() const = 0;
     virtual ~GameObject() {};

--- a/src/GameObjects/Light.cpp
+++ b/src/GameObjects/Light.cpp
@@ -43,7 +43,7 @@ void Light::calculateActiveDistance() {
     }
 }
 
-void Light::step(long time __attribute__((unused))) {
+void Light::step(long time [[gnu::unused]]) {
     if(lightType == DIRECTIONAL) {
         updateLightView();
 

--- a/src/GameObjects/Players/FreeCursorPlayer.cpp
+++ b/src/GameObjects/Players/FreeCursorPlayer.cpp
@@ -43,7 +43,7 @@ void FreeCursorPlayer::move(moveDirections direction) {
     }
 }
 
-void FreeCursorPlayer::rotate(float xPosition, float yPosition, float xChange __attribute__((unused)), float yChange __attribute__((unused))) {
+void FreeCursorPlayer::rotate(float xPosition, float yPosition, float xChange [[gnu::unused]], float yChange [[gnu::unused]]) {
     glm::vec2 cursorPosition((options->getScreenWidth()/2.0f)  + xPosition * options->getScreenWidth() /2.0f,
                              (options->getScreenHeight()/2.0f) - yPosition * options->getScreenHeight()/2.0f);//y is negative, because sdl reports opposite of OpenGL
 

--- a/src/GameObjects/Players/FreeCursorPlayer.h
+++ b/src/GameObjects/Players/FreeCursorPlayer.h
@@ -71,7 +71,7 @@ public:
 
     void registerToPhysicalWorld(btDiscreteDynamicsWorld *world [[gnu::unused]], int collisionGroup [[gnu::unused]], int collisionMaskForSelf [[gnu::unused]],
                                      int collisionMaskForGround [[gnu::unused]], const glm::vec3 &worldAABBMin [[gnu::unused]], const glm::vec3 &worldAABBMax [[gnu::unused]]) {}
-    void processPhysicsWorld(const btDiscreteDynamicsWorld *world __attribute__((unused))) {};
+    void processPhysicsWorld(const btDiscreteDynamicsWorld *world [[gnu::unused]]) {};
 
     void rotate(float xPosition, float yPosition, float xChange, float yChange);
 

--- a/src/GameObjects/Players/FreeMovingPlayer.cpp
+++ b/src/GameObjects/Players/FreeMovingPlayer.cpp
@@ -42,7 +42,7 @@ void FreeMovingPlayer::move(moveDirections direction) {
     }
 }
 
-void FreeMovingPlayer::rotate(float xPosition __attribute__((unused)), float yPosition __attribute__((unused)), float xChange, float yChange) {
+void FreeMovingPlayer::rotate(float xPosition [[gnu::unused]], float yPosition [[gnu::unused]], float xChange, float yChange) {
     glm::quat viewChange;
     float lookAroundSpeedX = options->getLookAroundSpeed();
     //scale look around speed with the abs(center.y). for 1 -> look around 0, for 0 -> lookaround 1.

--- a/src/GameObjects/Players/FreeMovingPlayer.h
+++ b/src/GameObjects/Players/FreeMovingPlayer.h
@@ -69,7 +69,7 @@ public:
                                      int collisionMaskForGround [[gnu::unused]], const glm::vec3 &worldAABBMin [[gnu::unused]], const glm::vec3 &worldAABBMax [[gnu::unused]]) {}
 
 
-    void processPhysicsWorld(const btDiscreteDynamicsWorld *world __attribute__((unused))) {};
+    void processPhysicsWorld(const btDiscreteDynamicsWorld *world [[gnu::unused]]) {};
 
     void rotate(float xPosition, float yPosition, float xChange, float yChange);
 

--- a/src/GameObjects/Players/MenuPlayer.cpp
+++ b/src/GameObjects/Players/MenuPlayer.cpp
@@ -6,11 +6,11 @@
 #include "../../Options.h"
 #include "../../GUI/GUIRenderable.h"
 
-void MenuPlayer::move(moveDirections direction __attribute((unused))) {
+void MenuPlayer::move(moveDirections direction [[gnu::unused]]) {
     //menu player can't move
 }
 
-void MenuPlayer::rotate(float xPosition, float yPosition, float xChange __attribute__((unused)), float yChange __attribute__((unused))) {
+void MenuPlayer::rotate(float xPosition, float yPosition, float xChange [[gnu::unused]], float yChange [[gnu::unused]]) {
     glm::vec2 cursorPosition((options->getScreenWidth()/2.0f)  + xPosition * options->getScreenWidth() /2.0f,
                              (options->getScreenHeight()/2.0f) - yPosition * options->getScreenHeight()/2.0f);//y is negative, because sdl reports opposite of OpenGL
 

--- a/src/GameObjects/Players/Player.h
+++ b/src/GameObjects/Players/Player.h
@@ -42,7 +42,7 @@ public:
         NONE, FORWARD, BACKWARD, LEFT, RIGHT, LEFT_FORWARD, RIGHT_FORWARD, LEFT_BACKWARD, RIGHT_BACKWARD, UP
     };
 
-    Player(GUIRenderable *cursor, Options *options, const glm::vec3 &position __attribute((unused)), const glm::vec3 &lookDirection __attribute((unused)))
+    Player(GUIRenderable *cursor, Options *options, const glm::vec3 &position [[gnu::unused]], const glm::vec3 &lookDirection [[gnu::unused]])
             : cursor(cursor), options(options){};
 
     virtual ~Player() {}

--- a/src/GameObjects/SkyBox.h
+++ b/src/GameObjects/SkyBox.h
@@ -42,7 +42,7 @@ public:
 
     void render();
 
-    void setupForTime(long time __attribute__((unused))) {};
+    void setupForTime(long time [[gnu::unused]]) {};
 
     ~SkyBox() {
         assetManager->freeAsset(cubeMap->getNames());

--- a/src/GamePlay/QuitGameOnTrigger.cpp
+++ b/src/GamePlay/QuitGameOnTrigger.cpp
@@ -11,7 +11,7 @@ std::vector<LimonAPI::ParameterRequest> QuitGameOnTrigger::getParameters() {
     return std::vector<LimonAPI::ParameterRequest>();
 }
 
-bool QuitGameOnTrigger::run(std::vector<LimonAPI::ParameterRequest> parameters __attribute((unused))) {
+bool QuitGameOnTrigger::run(std::vector<LimonAPI::ParameterRequest> parameters [[gnu::unused]]) {
     limonAPI->quitGame();
     return true;
 }

--- a/src/GamePlay/ReturnPreviousWorldOnTrigger.cpp
+++ b/src/GamePlay/ReturnPreviousWorldOnTrigger.cpp
@@ -11,7 +11,7 @@ std::vector<LimonAPI::ParameterRequest> ReturnPreviousWorldOnTrigger::getParamet
     return std::vector<LimonAPI::ParameterRequest>();
 }
 
-bool ReturnPreviousWorldOnTrigger::run(std::vector<LimonAPI::ParameterRequest> parameters __attribute((unused))) {
+bool ReturnPreviousWorldOnTrigger::run(std::vector<LimonAPI::ParameterRequest> parameters [[gnu::unused]]) {
     limonAPI->returnPreviousWorld();
     return true;
 }


### PR DESCRIPTION
__attribute__((unused))  and __attribute((unused)) tags replaced with [[gnu::unused]] 
Note: Not tested on Visual Studio
closes #87 